### PR TITLE
images: rhel-ubi: enable intel-trust-authority-as

### DIFF
--- a/kbs/docker/rhel-ubi/Dockerfile
+++ b/kbs/docker/rhel-ubi/Dockerfile
@@ -27,7 +27,7 @@ dnf -y --setopt=install_weak_deps=0 install \
 # Build.
 WORKDIR /usr/src/kbs
 COPY . .
-ARG KBS_FEATURES=coco-as-builtin
+ARG KBS_FEATURES=coco-as-builtin,intel-trust-authority-as
 RUN \
 # Build sgx_dcap_quoteverify stub.
 pushd sgx_dcap_quoteverify_stubs && \


### PR DESCRIPTION
kbs binary can be build using multiple AS backends and the choice is made runtime in the kbs-config.toml:

```toml
...
[attestation_service]
type = coco_as_builtin | coco_as_grpc | intel_ta
...
```