### PR TITLE
konflux: generate a new on-push build

### DIFF
--- a/.tekton/trustee-pull-request.yaml
+++ b/.tekton/trustee-pull-request.yaml
@@ -8,7 +8,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      target_branch == "main"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: trustee

--- a/.tekton/trustee-push.yaml
+++ b/.tekton/trustee-push.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
+      target_branch == "main"
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: trustee


### PR DESCRIPTION
This is a meaningless change in order to trigger a new on-push run on Konflux.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>