### PR TITLE
fix: enable package registry proxy for prefetch-dependencies

### DIFF
--- a/.tekton/trustee-pull-request.yaml
+++ b/.tekton/trustee-pull-request.yaml
@@ -164,6 +164,8 @@ spec:
         value: $(params.image-expires-after)
       - name: dev-package-managers
         value: "true"
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - init
       taskRef:
@@ -189,6 +191,8 @@ spec:
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
       - name: dev-package-managers
+        value: "true"
+      - name: enable-package-registry-proxy
         value: "true"
       runAfter:
       - clone-repository

--- a/.tekton/trustee-push.yaml
+++ b/.tekton/trustee-push.yaml
@@ -155,6 +155,8 @@ spec:
         value: $(params.output-image).git
       - name: dev-package-managers
         value: "true"
+      - name: enable-package-registry-proxy
+        value: "true"
       runAfter:
       - init
       taskRef:
@@ -178,6 +180,8 @@ spec:
       - name: ociStorage
         value: $(params.output-image).prefetch
       - name: dev-package-managers
+        value: "true"
+      - name: enable-package-registry-proxy
         value: "true"
       runAfter:
       - clone-repository


### PR DESCRIPTION
Set enable-package-registry-proxy to true in all prefetch-dependencies tasks to satisfy the prefetch_dependencies.package_registry_proxy_enabled EC policy, effective since 2026-05-13.