### PR TITLE
konflux: add PR tags to images for easier identification

### DIFF
--- a/.tekton/trustee-pull-request.yaml
+++ b/.tekton/trustee-pull-request.yaml
@@ -546,6 +546,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Tag images with the PR number they were built from, making it easier to identify which image to use for testing before merging.

Two tags are created:
- pr-[PR number]: overridden on each build, tags the latest build
- pullreq-[PR number]-[head commit SHA]: provides history of builds

See https://github.com/openshift/sandboxed-containers-operator/pull/2454 for further references.