### PR TITLE
fix(deps): bump curl-sys to 0.4.90+curl-8.21.0 for CVE-2026-8927

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.88+curl-8.20.0"
+version = "0.4.90+curl-8.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644816de6547255eff4e491a1dda1c19b7237f00b62a61e6e64859ce4f2906d0"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

- Bumps transitive dependency **curl-sys** from `0.4.88+curl-8.20.0` to `0.4.90+curl-8.21.0`
- Resolves **CVE-2026-8927**: libcurl proxy authentication state leak (information disclosure)
- Updated via `cargo update -p curl-sys`

## Context

**CVE:** CVE-2026-8927
**Vulnerable range:** curl-sys < 0.4.89+curl-8.21.0
**Jira ticket:** [KATA-5734](https://redhat.atlassian.net/browse/KATA-5734)

🤖 Generated with [Claude Code](https://claude.com/claude-code)